### PR TITLE
CI + MSRV checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, next ]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            target/debug/.cargo-lock
+            target/.cargo-lock
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Run tests
+        run: cargo test --all
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-msrv
+        run: cargo install cargo-msrv
+      - name: Cache rustup toolchains
+        run: rustup update
+      - name: Check MSRV for each workspace member
+        run: |
+          chmod +x scripts/check-msrv.sh
+          ./scripts/check-msrv.sh

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,0 +1,34 @@
+name: Check MSRV
+
+on:
+  push:
+    branches: [next]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+# Limits workflow concurrency to only the latest commit in the PR.
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Check MSRV (aka `rust-version`) in `Cargo.toml` is valid for workspace members
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-msrv
+        run: cargo install cargo-msrv
+      - name: Cache rustup toolchains
+        run: rustup update
+      - name: Check MSRV for each workspace member
+        run: |
+          chmod +x scripts/check-msrv.sh
+          ./scripts/check-msrv.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+resolver = "2"
 members = [
   "diagnostics",
   "diagnostics-macros",

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,150 @@
+# -------------------------------------------------------------------------------------------------
+# Makefile for miden-diagnostics
+# -------------------------------------------------------------------------------------------------
+
+.DEFAULT_GOAL := help
+
+# -- help -----------------------------------------------------------------------------------------
+.PHONY: help
+help:
+	@printf "\nTargets:\n\n"
+	@awk 'BEGIN {FS = ":.*##"; OFS = ""} /^[a-zA-Z0-9_.-]+:.*?##/ { printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+	@printf "\nTesting:\n"
+	@printf "  make test                      # Run all tests\n"
+	@printf "  make test-diagnostics         # Test diagnostics crate\n"
+	@printf "  make test-diagnostics-macros  # Test diagnostics-macros crate\n"
+	@printf "  make test-fast                # Fast tests only\n"
+	@printf "\nQuality:\n"
+	@printf "  make format                   # Format code\n"
+	@printf "  make format-check             # Check formatting\n"
+	@printf "  make clippy                  # Run clippy linter\n"
+	@printf "  make lint                    # Run all quality checks\n"
+	@printf "\nDocumentation:\n"
+	@printf "  make doc                      # Generate documentation\n"
+	@printf "  make test-docs                # Test documentation\n"
+	@printf "\nBuilding:\n"
+	@printf "  make build                    # Build project\n"
+	@printf "  make check                   # Check without building\n"
+	@printf "\nCI:\n"
+	@printf "  make ci                      # Run CI checks locally\n"
+	@printf "\n"
+
+# -- environment toggles --------------------------------------------------------------------------
+BACKTRACE := RUST_BACKTRACE=1
+WARNINGS  := RUSTDOCFLAGS="-D warnings"
+
+# -- feature configuration ------------------------------------------------------------------------
+WORKSPACE_FEATURES :=
+DEFAULT_TEST_FEATURES :=
+
+# -- linting --------------------------------------------------------------------------------------
+
+.PHONY: clippy
+clippy: ## Runs Clippy with configs
+	cargo clippy --workspace --all-targets -- -D warnings
+
+.PHONY: fix
+fix: ## Runs Fix with configs
+	cargo fix --allow-dirty --all-targets
+
+.PHONY: format
+format: ## Runs Format
+	cargo fmt --all
+
+.PHONY: format-check
+format-check: ## Runs Format in check mode
+	cargo fmt --all --check
+
+.PHONY: lint
+lint: format fix clippy ## Runs all linting tasks at once
+
+# -- testing --------------------------------------------------------------------------------------
+
+# Core knobs (overridable from CLI)
+CRATE   ?=
+FEATURES ?=
+EXPR    ?=
+EXTRA   ?=
+
+define _CARGO_TEST
+	$(BACKTRACE) cargo test \
+		$(if $(FEATURES),--features $(FEATURES),) \
+		$(if $(CRATE),-p $(CRATE),) \
+		$(EXTRA) $(EXPR)
+endef
+
+.PHONY: core-test core-test-build
+## Core: run tests with overridable parameters
+core-test:
+	$(_CARGO_TEST)
+
+## Core: build test binaries only (no run)
+core-test-build:
+	$(BACKTRACE) cargo test --no-run \
+		$(if $(FEATURES),--features $(FEATURES),) \
+		$(if $(CRATE),-p $(CRATE),) \
+		$(EXTRA) $(EXPR)
+
+# Pattern rule for testing individual crates
+.PHONY: test-%
+test-%: ## Tests a specific crate; accepts 'test=' to pass a selector
+	$(MAKE) core-test \
+		CRATE=miden-$* \
+		FEATURES=$(FEATURES_$*) \
+		EXPR=$(if $(test),$(test),)
+
+# Workspace-wide tests
+.PHONY: test-build
+test-build: ## Build test binaries for workspace
+	$(MAKE) core-test-build
+
+.PHONY: test
+test: ## Run all tests for workspace
+	$(MAKE) core-test
+
+.PHONY: test-docs
+test-docs: ## Run documentation tests
+	cargo test --doc
+
+# Filtered test runs
+.PHONY: test-fast
+test-fast: ## Runs fast tests (excludes slow tests)
+	$(MAKE) core-test \
+		EXPR="-- --skip slow_test"  # Adjust skip pattern as needed
+
+# --- checking ------------------------------------------------------------------------------------
+
+.PHONY: check
+check: ## Checks all targets for errors
+	cargo check --all-targets
+
+# --- building ------------------------------------------------------------------------------------
+
+.PHONY: build
+build: ## Builds project with release profile
+	cargo build --release
+
+# --- documentation ------------------------------------------------------------------------------
+
+.PHONY: doc
+doc: ## Generates & checks documentation
+	$(WARNINGS) cargo doc --workspace --keep-going --release
+
+# --- CI ------------------------------------------------------------------------------------------
+
+.PHONY: ci
+ci: ## Run CI checks locally
+	@echo "Running CI checks locally..."
+	@echo "1. Checking formatting..."
+	@cargo fmt --all -- --check
+	@echo "2. Running clippy..."
+	@cargo clippy --workspace --all-targets -- -D warnings
+	@echo "3. Running tests..."
+	@cargo nextest run --profile ci
+	@echo "4. Checking MSRV..."
+	@chmod +x scripts/check-msrv.sh && ./scripts/check-msrv.sh
+	@echo "CI checks completed successfully!"
+
+# Crate-specific features (adjust as needed)
+FEATURES_diagnostics :=
+FEATURES_diagnostics-macros :=

--- a/diagnostics/src/diagnostic.rs
+++ b/diagnostics/src/diagnostic.rs
@@ -156,7 +156,7 @@ impl<'h> InFlightDiagnostic<'h> {
         self.diagnostic
     }
 
-    /// Emit the underlying [Diagnostic] via the [DiagnosticHandler]
+    /// Emit the underlying [Diagnostic] via the [DiagnosticsHandler]
     pub fn emit(self) {
         self.handler.emit(self.diagnostic);
     }

--- a/diagnostics/src/filename.rs
+++ b/diagnostics/src/filename.rs
@@ -34,7 +34,7 @@ impl<'a> From<&'a FileName> for &'a Path {
         }
     }
 }
-impl<'a> From<&'a Path> for FileName {
+impl From<&Path> for FileName {
     fn from(name: &Path) -> FileName {
         FileName::real(name)
     }

--- a/diagnostics/src/index.rs
+++ b/diagnostics/src/index.rs
@@ -11,7 +11,7 @@ use super::SourceId;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SourceIndex(NonZeroUsize);
 impl SourceIndex {
-    const INDEX_MASK: usize = u32::max_value() as usize;
+    const INDEX_MASK: usize = u32::MAX as usize;
 
     const UNKNOWN_SRC_ID: usize = (SourceId::UNKNOWN_SOURCE_ID as usize) << 32;
 

--- a/diagnostics/src/index.rs
+++ b/diagnostics/src/index.rs
@@ -7,7 +7,7 @@ use super::SourceId;
 
 /// [SourceIndex] is a compact representation of a byte index in a specific source file.
 ///
-/// It has a canonical representation for "unknown" indices, similar to that of [SourceSpan]
+/// It has a canonical representation for "unknown" indices, similar to that of [crate::span::SourceSpan]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SourceIndex(NonZeroUsize);
 impl SourceIndex {

--- a/diagnostics/src/source.rs
+++ b/diagnostics/src/source.rs
@@ -8,7 +8,7 @@ use super::*;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SourceId(pub(crate) NonZeroU32);
 impl SourceId {
-    pub(crate) const UNKNOWN_SOURCE_ID: u32 = u32::max_value();
+    pub(crate) const UNKNOWN_SOURCE_ID: u32 = u32::MAX;
 
     pub const UNKNOWN: Self = Self(unsafe { NonZeroU32::new_unchecked(Self::UNKNOWN_SOURCE_ID) });
 

--- a/diagnostics/src/span.rs
+++ b/diagnostics/src/span.rs
@@ -16,7 +16,7 @@ use super::{SourceId, SourceIndex};
 /// it maps using the `CodeMap` from which it was created:
 ///
 /// * Can be used to get a `str` of the original file content containing
-/// just the specified range.
+///   just the specified range.
 /// * Can be used to get file/line/column at which the span starts
 /// * Can be used to get the [SourceFile] from which it is derived
 ///

--- a/diagnostics/src/span.rs
+++ b/diagnostics/src/span.rs
@@ -18,7 +18,7 @@ use super::{SourceId, SourceIndex};
 /// * Can be used to get a `str` of the original file content containing
 ///   just the specified range.
 /// * Can be used to get file/line/column at which the span starts
-/// * Can be used to get the [SourceFile] from which it is derived
+/// * Can be used to get the [crate::source::SourceFile] from which it is derived
 ///
 /// A [SourceSpan] has a canonical "default" value, which is represented
 /// by `SourceSpan::UNKNOWN`. It can be treated like a regular span, however
@@ -96,7 +96,7 @@ impl SourceSpan {
         SourceIndex::new(self.source_id, self.start)
     }
 
-    /// Returns the starting [ByteIndex] of this span in its [SourceFile]
+    /// Returns the starting [ByteIndex] of this span in its [crate::source::SourceFile]
     #[inline(always)]
     pub fn start_index(&self) -> ByteIndex {
         self.start
@@ -201,7 +201,7 @@ impl<T: ?Sized> Spanned for Span<T> {
     }
 }
 impl<T> Span<T> {
-    /// Construct a new [Span] from a [SourceSpan] and a [T]
+    /// Construct a new [Span] from a [SourceSpan] and a generic item
     pub const fn new(span: SourceSpan, item: T) -> Self {
         Self { span, item }
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.90"
+components = ["rustfmt", "rust-src", "clippy"]
+targets = ["wasm32-unknown-unknown"]
+profile = "minimal"

--- a/scripts/check-msrv.sh
+++ b/scripts/check-msrv.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+# Enhanced MSRV checking script for workspace repository
+# Checks MSRV for each workspace member and provides helpful error messages
+
+# ---- utilities --------------------------------------------------------------
+
+check_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: Required command '$1' is not installed or not in PATH"
+    exit 1
+  fi
+}
+
+# Check required commands
+check_command "cargo"
+check_command "jq"
+check_command "rustup"
+check_command "sed"
+check_command "grep"
+check_command "awk"
+
+# Portable in-place sed (GNU/macOS); usage: sed_i 's/foo/bar/' file
+# shellcheck disable=SC2329  # used quoted
+sed_i() {
+  if sed --version >/dev/null 2>&1; then
+    sed -i "$@"
+  else
+    sed -i '' "$@"
+  fi
+}
+
+# ---- repo root --------------------------------------------------------------
+
+# Get the directory where this script is located and change to the parent directory
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$DIR/.."
+
+echo "Checking MSRV for workspace members..."
+
+# ---- metadata --------------------------------------------------------------
+
+metadata_json="$(cargo metadata --no-deps --format-version 1)"
+workspace_root="$(printf '%s' "$metadata_json" | jq -r '.workspace_root')"
+
+failed_packages=""
+
+# Iterate actual workspace packages with manifest paths and (maybe) rust_version
+# Fields per line (TSV): id  name  manifest_path  rust_version_or_empty
+while IFS=$'\t' read -r pkg_id package_name manifest_path rust_version; do
+  # Derive package directory (avoid external dirname for portability)
+  package_dir="${manifest_path%/*}"
+  if [[ -z "$package_dir" || "$package_dir" == "$manifest_path" ]]; then
+    package_dir="."
+  fi
+
+  echo "Checking $package_name ($pkg_id) in $package_dir"
+
+  if [[ ! -f "$package_dir/Cargo.toml" ]]; then
+    echo "WARNING: No Cargo.toml found in $package_dir, skipping..."
+    continue
+  fi
+
+  # Prefer cargo metadata's effective rust_version if present
+  current_msrv="$rust_version"
+  if [[ -z "$current_msrv" ]]; then
+    # If the crate inherits: rust-version.workspace = true
+    if grep -Eq '^\s*rust-version\.workspace\s*=\s*true\b' "$package_dir/Cargo.toml"; then
+      # Read from workspace root [workspace.package]
+      current_msrv="$(grep -Eo '^\s*rust-version\s*=\s*"[^"]+"' "$workspace_root/Cargo.toml" | head -n1 | sed -E 's/.*"([^"]+)".*/\1/')"
+      if [[ -n "$current_msrv" ]]; then
+        echo "   Using workspace MSRV: $current_msrv"
+      fi
+    fi
+  fi
+
+  if [[ -z "$current_msrv" ]]; then
+    echo "WARNING: No rust-version found (package or workspace) for $package_name"
+    continue
+  fi
+
+  echo "   Current MSRV: $current_msrv"
+
+  # Try to verify the MSRV
+  if ! cargo msrv verify --manifest-path "$package_dir/Cargo.toml" >/dev/null 2>&1; then
+    echo "ERROR: MSRV check failed for $package_name"
+    failed_packages="$failed_packages $package_name"
+
+    echo "Searching for correct MSRV for $package_name..."
+
+    # Determine the currently-installed stable toolchain version (e.g., "1.81.0")
+    latest_stable="$(rustup run stable rustc --version 2>/dev/null | awk '{print $2}')"
+    if [[ -z "$latest_stable" ]]; then latest_stable="1.81.0"; fi
+
+    # Search for the actual MSRV starting from the current one
+    if actual_msrv=$(cargo msrv find \
+          --manifest-path "$package_dir/Cargo.toml" \
+          --min "$current_msrv" \
+          --max "$latest_stable" \
+          --output-format minimal 2>/dev/null); then
+      echo "   Found actual MSRV: $actual_msrv"
+      echo ""
+      echo "ERROR SUMMARY for $package_name:"
+      echo "   Package:   $package_name"
+      echo "   Directory: $package_dir"
+      echo "   Current (incorrect) MSRV: $current_msrv"
+      echo "   Correct MSRV:             $actual_msrv"
+      echo ""
+      echo "TO FIX:"
+      echo "   Update rust-version in $package_dir/Cargo.toml from \"$current_msrv\" to \"$actual_msrv\""
+      echo ""
+      echo "   Or run this command (portable in-place edit):"
+      echo "     sed_i 's/^\\s*rust-version\\s*=\\s*\"$current_msrv\"/rust-version = \"$actual_msrv\"/' \"$package_dir/Cargo.toml\""
+    else
+      echo "   Could not determine correct MSRV automatically"
+      echo ""
+      echo "ERROR SUMMARY for $package_name:"
+      echo "   Package:   $package_name"
+      echo "   Directory: $package_dir"
+      echo "   Current (incorrect) MSRV: $current_msrv"
+      echo "   Could not automatically determine correct MSRV"
+      echo ""
+      echo "TO FIX:"
+      echo "   Run manually: cargo msrv find --manifest-path \"$package_dir/Cargo.toml\""
+    fi
+    echo "-------------------------------------------------------------------------------"
+  else
+    echo "OK: MSRV check passed for $package_name"
+  fi
+  echo ""
+
+done < <(
+  printf '%s' "$metadata_json" \
+  | jq -r '. as $m
+           | $m.workspace_members[]
+           | . as $id
+           | ($m.packages[] | select(.id == $id)
+              | [ .id, .name, .manifest_path, (.rust_version // "") ] | @tsv)'
+)
+
+if [[ -n "$failed_packages" ]]; then
+  echo "MSRV CHECK FAILED"
+  echo ""
+  echo "The following packages have incorrect MSRV settings:$failed_packages"
+  echo ""
+  echo "Please fix the rust-version fields in the affected Cargo.toml files as shown above."
+  exit 1
+else
+  echo "ALL WORKSPACE MEMBERS PASSED MSRV CHECKS!"
+  exit 0
+fi


### PR DESCRIPTION
This is essentially a port of https://github.com/0xMiden/crypto/pull/547 on this repo **+ a very basic CI setup, absent from main**

Copying the PR description from there.

----
This adds a CI job (locally runnable) that will check the MSRV of a PR is set correctly on a crate-by-crate basis. If the MSRV is set incorrectly, due to e.g. some feature being used, it will compute the correct MSRV for that crate and indicate it in its error. 

The script's error message can be emulated by manually changing the MSRV to an incorrect version (e.g. "1.87") and running it (`./scripts/check-msrv.sh`).
<details><summary> Sample output (click to unfold) </summary>

```
Checking MSRV for workspace members...
Checking miden-crypto in /Users/huitseeker/tmp/crypto/miden-crypto
   Current MSRV: 1.87
ERROR: MSRV check failed for miden-crypto
Searching for correct MSRV for miden-crypto...
   Found actual MSRV: 1.88.0

ERROR SUMMARY for miden-crypto:
   Package:   miden-crypto
   Directory: /Users/huitseeker/tmp/crypto/miden-crypto
   Current (incorrect) MSRV: 1.87
   Correct MSRV:             1.88.0

TO FIX:
   Update rust-version in /Users/huitseeker/tmp/crypto/miden-crypto/Cargo.
toml from "1.87" to "1.88.0"

   Or run this command (portable in-place edit):
     sed_i 's/^\s*rust-version\s*=\s*"1.87"/rust-version = "1.88.0"/' "/Us
ers/huitseeker/tmp/crypto/miden-crypto/Cargo.toml"
--------------------------------------------------------------------------
-----
```
</details>


This further adds a rust-toolchain file that will make CI tooling (and local rustup dev envs) follow the latest stable as it updates.

As a consequence, the following behaviors can change from being proactive to being on-demand:
- bumping the MSRV.

As a side effect, we can expect the MSRV setting to (over time) accurately reflect what we can compile with. Right now, the project or any of its dependents cannot be compiled with Rust 1.88 (and there is not technical reason to impose this restriction).

----

TL;DR:
- the file that drives toolchain bumps is `rust-toolchain.toml`, not the MSRV,
- when using a feature that requires a higher MSRV the script (in CI or locally) helps figure out the adjustment necessary to optimally set the MSRV.